### PR TITLE
NGX-261: use fqdn for 'apache2_module'

### DIFF
--- a/tasks/configure/debian.yml
+++ b/tasks/configure/debian.yml
@@ -20,7 +20,7 @@
   when: ansible_os_family|lower == "debian"
 
 - name: (Debian) Enable Apache modules
-  apache2_module:
+  community.general.apache2_module:
     name: "{{ item }}"
     state: present
     ignore_configcheck: true


### PR DESCRIPTION
- Use the fqdn ansible module path for apache2_module.