### PR TITLE
NGX-285: cast mpm_conf_max_request_workers to int before performing division operation

### DIFF
--- a/templates/etc/httpd/modules.d/00-mpm.conf.j2
+++ b/templates/etc/httpd/modules.d/00-mpm.conf.j2
@@ -9,7 +9,7 @@ LoadModule mpm_event_module {{ apache_modules_path }}/mod_mpm_event.so
 {% endif %}
 
 <IfModule mpm_event_module>
-    ServerLimit             {{ mpm_conf_max_request_workers|int / 25 }}
+    ServerLimit             {{ mpm_conf_max_request_workers | int / 25 }}
     StartServers            5
     MinSpareThreads         75
     MaxSpareThreads         250

--- a/templates/etc/httpd/modules.d/00-mpm.conf.j2
+++ b/templates/etc/httpd/modules.d/00-mpm.conf.j2
@@ -9,7 +9,7 @@ LoadModule mpm_event_module {{ apache_modules_path }}/mod_mpm_event.so
 {% endif %}
 
 <IfModule mpm_event_module>
-    ServerLimit             {{ mpm_conf_max_request_workers / 25 }}
+    ServerLimit             {{ mpm_conf_max_request_workers|int / 25 }}
     StartServers            5
     MinSpareThreads         75
     MaxSpareThreads         250


### PR DESCRIPTION
- When this variable is passed as an extra varibable via ansible-semaphore, the variable must be casted to an int, so that the division operation can be completed.