### PR TITLE
NGX-335: convert ServerLimit to int

### DIFF
--- a/templates/etc/httpd/modules.d/00-mpm.conf.j2
+++ b/templates/etc/httpd/modules.d/00-mpm.conf.j2
@@ -9,7 +9,7 @@ LoadModule mpm_event_module {{ apache_modules_path }}/mod_mpm_event.so
 {% endif %}
 
 <IfModule mpm_event_module>
-    ServerLimit             {{ mpm_conf_max_request_workers | int / 25 }}
+    ServerLimit             {{ (mpm_conf_max_request_workers | int / 25 ) | int }}
     StartServers            5
     MinSpareThreads         75
     MaxSpareThreads         250


### PR DESCRIPTION
- Because we pass mpm_conf_max_request_workers as a string - it must be converted to an int.  Additonally, the division by 25 needs to be converted to an int.