### PR TITLE
NGX-343: adjust systemd restart default behavior to not automatically restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Available variables are listed below with their default values (you can also see
 | apache_modules_path        | Default: `/etc/{{ apache_name }}/modules`
 | apache_modules_config_path | Default: `/etc/{{ apache_name }}/conf.modules.d`
 | apache_packages            | The list of Apache packages to install
+| apache_systemd_restart     | Default: `false`
 
 ## Example Playbook
 ```yaml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,10 @@
 
 - name: Include systemd restart configuration
   include: systemd.yml
-  when: ansible_service_mgr == "systemd"
+  when: >-
+    ( apache_systemd_restart|default(False)
+    or systemd_restart|default(False) )
+    and systemd_restart_setting is defined  
 
 - name: Start and enable Apache service
   service:


### PR DESCRIPTION
- The default behavior should be that systemd restart configuration is not applied.