### PR TITLE
NGX-357: Create Apache /server-status config

### DIFF
--- a/tasks/configure/main.yml
+++ b/tasks/configure/main.yml
@@ -23,3 +23,13 @@
     mode: 0644
   notify:
     - restart apache
+
+- name: Create Apache /server-status config
+  template:
+    src: etc/httpd/conf.d/status.conf.j2
+    dest: "{{ apache_config_site_path }}/status.conf"
+    owner: root
+    group: root
+    mode: 0644
+  notify:
+    - restart apache

--- a/templates/etc/httpd/conf.d/status.conf.j2
+++ b/templates/etc/httpd/conf.d/status.conf.j2
@@ -1,0 +1,11 @@
+# {{ template_destpath }}
+# {{ ansible_managed }}
+
+<IfModule status_module>
+    <Location /server-status>
+        SetHandler server-status
+        Order deny,allow
+        Deny from all
+        Allow from 127.0.0.1
+    </Location>
+</IfModule>


### PR DESCRIPTION
- Create an additional apache config file which provides handling for mod_status if it is installed and loaded.  This allows for troubleshooting using the [Apache Module mod_status](https://httpd.apache.org/docs/2.4/mod/mod_status.html).