### PR TITLE
NGX-864: Set Apache Timeout to a default of 300 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Available variables are listed below with their default values (you can also see
 | apache_modules_config_path | Default: `/etc/{{ apache_name }}/conf.modules.d`
 | apache_packages            | The list of Apache packages to install
 | apache_systemd_restart     | Default: `false`
+| apache_timeout             | Default: `300`
 
 ## Example Playbook
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ apache_user: apache
 
 apache_port_http: 80
 apache_port_https: 443
+apache_timeout: 300
 
 apache_config: /etc/{{ apache_name }}/conf/{{ apache_name }}.conf
 apache_config_path: /etc/{{ apache_name }}/conf.d

--- a/tasks/configure/main.yml
+++ b/tasks/configure/main.yml
@@ -33,3 +33,9 @@
     mode: "0644"
   notify:
     - Restart apache
+
+- name: Set Apache Timeout Directive
+  ansible.builtin.lineinfile:
+    path: "{{ apache_config }}"
+    regexp: '^Timeout\s+\d+'
+    line: "Timeout {{ apache_timeout }}"


### PR DESCRIPTION
- This allows long running php scripts which have been proxed to an fpm socket to complete